### PR TITLE
Bring this plugin a bit more up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,45 +100,31 @@ Click to see an example partial highlighting setup.
 </summary>
 
 ```scm
-(con_unit) @symbol  ; unit, as in ()
-
 (comment) @comment
+(comment) @spell
 
 ;; ----------------------------------------------------------------------------
 ;; Functions and variables
 
 (variable) @variable
-(pat_wildcard) @variable
-(signature name: (variable) @variable)
-
-(function
-  name: (variable) @function
-  patterns: (patterns))
-(function
-  name: (variable) @function
-  rhs: (exp_lambda))
-((signature (variable) @function (fun)) . (function (variable)))
-((signature (variable) @_type (fun)) . (function (variable) @function) (#eq? @function @_type))
-((signature (variable) @function (context (fun))) . (function (variable)))
-((signature (variable) @_type (context (fun))) . (function (variable) @function) (#eq? @function @_type))
-((signature (variable) @function (forall (context (fun)))) . (function (variable)))
-((signature (variable) @_type (forall (context (fun)))) . (function (variable) @function) (#eq? @function @_type))
-
-(exp_infix (variable) @operator)  ; consider infix functions as operators
-(exp_section_right (variable) @operator) ; partially applied infix functions (sections) also get highlighted as operators
-(exp_section_left (variable) @operator)
-
-(exp_infix (exp_name) @function.call (#set! "priority" 101))
-(exp_apply . (exp_name (variable) @function.call))
-(exp_apply . (exp_name (qualified_variable (variable) @function.call)))
-
+(pattern/wildcard) @variable
+(decl/signature name: (variable) @variable)
 
 ;; ----------------------------------------------------------------------------
 ;; Types
 
-(type) @type
-(type_star) @type
-(type_variable) @type
+(type/unit) @type
+
+(type/unit [
+  "("
+  ")"
+] @type)
+
+(type/list [
+  "["
+  "]"
+] @type)
+(type/star) @type
 
 (constructor) @constructor
 

--- a/lua/haskell-scope-highlighting/highlighter.lua
+++ b/lua/haskell-scope-highlighting/highlighter.lua
@@ -1,5 +1,6 @@
 local hs_treesitter = require("haskell-scope-highlighting.treesitter")
 local utils = require("haskell-scope-highlighting.utils")
+local ts = require("nvim-treesitter.compat")
 local M = {}
 
 M.options = {
@@ -204,7 +205,7 @@ function M.update()
 
 	if variable_expression_nodes ~= nil then
 		for _, node in ipairs(variable_expression_nodes) do
-			local text = vim.treesitter.query.get_node_text(node, bufnr)
+			local text = ts.get_node_text(node, bufnr)
 
 			local range = { vim.treesitter.get_node_range(node) }
 			local hlgroup = nil

--- a/queries/haskell/scope_highlighting.scm
+++ b/queries/haskell/scope_highlighting.scm
@@ -1,4 +1,5 @@
 
+; NOTE: These commented queries are outdated, for tree-sitter-haskell < v0.21
 ; @function.call from nvim-treesitter/queries/haskell/highlights.scm
 ; (exp_infix (exp_name) @function.call (#set! "priority" 101))
 ; (exp_apply . (exp_name (variable) @function.call))
@@ -6,15 +7,15 @@
 ; (quoter) @function.call
 
 [
- (exp_lambda)
+ (expression/lambda)
  (function)
- (exp_do)
+ (expression/do)
 ] @scope
 
 
 (function name: (variable) @variable_declaration)
-(pat_name (variable) @variable_declaration)
+(pattern (variable) @variable_declaration)
 
-(exp_name (variable) @variable_expression (#not-any-of? @variable_expression "return" "otherwise"))
-(exp_name (qualified_variable) @variable_expression)
+(expression (variable) @variable_expression (#not-any-of? @variable_expression "return" "otherwise"))
+(expression (qualified (variable)) @variable_expression)
 


### PR DESCRIPTION
Hey :wave: 

This PR adds two fixes:

1. Neovim has removed `vim.treesitter.get_node_text`, which was still called.
2. tree-sitter-haskell has had a grammar rewrite:
   - https://github.com/nvim-treesitter/nvim-treesitter/pull/6580
   - https://github.com/tree-sitter/tree-sitter-haskell/pull/120
   This PR updates the queries. I've removed some highlight queries
   from the readme's snippet, because the highlights in nvim-treesitter have changed quite a bit since then.
   You might want to play around with that. I would really like to try out this plugin in more depth, but I probably won't have time anytime soon.